### PR TITLE
Fixed authenticateClient argument

### DIFF
--- a/src/Client.php
+++ b/src/Client.php
@@ -66,7 +66,7 @@ class Client
             $request = new Request($notification, $this->isProductionEnv);
             $handles[] = $ch = curl_init();
 
-            $this->authProvider->authenticateClient($ch);
+            $this->authProvider->authenticateClient($request);
 
             curl_setopt_array($ch, $request->getOptions());
             curl_setopt($ch, CURLOPT_HTTPHEADER, $request->getDecoratedHeaders());


### PR DESCRIPTION
This fixes a bug where a curl handler was passed to `authProvider->authenticateClient` instead of an instance of `Request`.