### PR TITLE
Limit number of simultaneous connections to prevent timeout errors

### DIFF
--- a/src/Client.php
+++ b/src/Client.php
@@ -74,32 +74,36 @@ class Client
 
             curl_setopt_array($ch, $request->getOptions());
             curl_setopt($ch, CURLOPT_HTTPHEADER, $request->getDecoratedHeaders());
-
-            curl_multi_add_handle($mh, $ch);
         }
 
-        $active = null;
-        do {
-            $mrc = curl_multi_exec($mh, $active);
-        } while ($mrc == CURLM_CALL_MULTI_PERFORM);
-
-        while ($active && $mrc == CURLM_OK) {
-            if (curl_multi_select($mh) != -1) {
-                do {
-                    $mrc = curl_multi_exec($mh, $active);
-                } while ($mrc == CURLM_CALL_MULTI_PERFORM);
-            }
+        $rolling_window = 10;
+        $rolling_window = count($handles) > $rolling_window ? $rolling_window : count($handles);
+        for ($i = 0; $i < $rolling_window; $i++) {
+            curl_multi_add_handle($mh, $handles[$i]);
         }
 
         $responseCollection = [];
-        foreach ($handles as $handle) {
-            curl_multi_remove_handle($mh, $handle);
-            $result = curl_multi_getcontent($handle);
+        do {
+            while(($execrun = curl_multi_exec($mh, $running)) == CURLM_CALL_MULTI_PERFORM);
+            if($execrun != CURLM_OK)
+                break;
+            while($done = curl_multi_info_read($mh)) {
+                $handle = $done['handle'];
 
-            list($headers, $body) = explode("\r\n\r\n", $result, 2);
-            $statusCode = curl_getinfo($handle, CURLINFO_HTTP_CODE);
-            $responseCollection[] = new Response($statusCode, $headers, $body);
-        }
+                $result = curl_multi_getcontent($handle);
+
+                list($headers, $body) = explode("\r\n\r\n", $result, 2);
+                $statusCode = curl_getinfo($handle, CURLINFO_HTTP_CODE);
+                $responseCollection[] = new Response($statusCode, $headers, $body);
+
+                if(isset($handles[$i])) {
+                    curl_multi_add_handle($mh, $handles[$i]);
+                }
+                $i++;
+
+                curl_multi_remove_handle($mh, $handle);
+            }
+        } while ($running);
 
         curl_multi_close($mh);
 

--- a/src/Payload.php
+++ b/src/Payload.php
@@ -26,6 +26,7 @@ class Payload implements \JsonSerializable
     const PAYLOAD_BADGE_KEY = 'badge';
     const PAYLOAD_SOUND_KEY = 'sound';
     const PAYLOAD_CONTENT_AVAILABLE_KEY = 'content-available';
+    const PAYLOAD_MUTABLE_CONTENT_KEY = 'mutable-content';
     const PAYLOAD_CATEGORY_KEY = 'category';
     const PAYLOAD_THREAD_ID_KEY = 'thread-id';
 
@@ -61,6 +62,13 @@ class Payload implements \JsonSerializable
      * @var bool
      */
     private $contentAvailable;
+
+    /**
+     * Include this key with a value of true to configure a mutable content notification.
+     *
+     * @var bool
+     */
+    private $mutableContent;
 
     /**
      * Provide this key with a string value that represents the notification’s type.
@@ -173,6 +181,19 @@ class Payload implements \JsonSerializable
     public function setContentAvailability(bool $value): Payload
     {
         $this->contentAvailable = $value;
+
+        return $this;
+    }
+
+    /**
+     * Set mutable content.
+     *
+     * @param bool $value
+     * @return Payload
+     */
+    public function setMutableContent(bool $value): Payload
+    {
+        $this->mutableContent = $value;
 
         return $this;
     }
@@ -302,6 +323,10 @@ class Payload implements \JsonSerializable
 
         if (is_bool($this->contentAvailable)) {
             $payload[self::PAYLOAD_ROOT_KEY][self::PAYLOAD_CONTENT_AVAILABLE_KEY] = (int)$this->contentAvailable;
+        }
+
+        if (is_bool($this->mutableContent)) {
+            $payload[self::PAYLOAD_ROOT_KEY][self::PAYLOAD_MUTABLE_CONTENT_KEY] = (int)$this->mutableContent;
         }
 
         if (is_string($this->category)) {


### PR DESCRIPTION
When sending > 200 notifications at once, some would cause timeout errors. This change limits the number of concurrent requests to prevent this.