### PR TITLE
Limited number of simultaneous connections to prevent timeout errors

### DIFF
--- a/README.md
+++ b/README.md
@@ -85,7 +85,7 @@ $client->addNotifications($notifications);
 
 $responses = $client->push(); // returns an array of ApnsResponseInterface (one Response per Notification)
 
-foreach ($responses as $response) {
+foreach ($responses as $devicetoken => $response) {
     $response->getApnsId();
     $response->getStatusCode();
     $response->getReasonPhrase();


### PR DESCRIPTION
Limited number of simultaneous connections to prevent timeout errors when sending 200+ notifications.

Array returned by push method now has device token as key.