### PR TITLE
Bugfix/connection limit

### DIFF
--- a/src/Client.php
+++ b/src/Client.php
@@ -90,10 +90,11 @@ class Client
                     $handle = $done['handle'];
 
                     $result = curl_multi_getcontent($handle);
+                    $token = curl_getinfo($handle, CURLINFO_PRIVATE);
 
                     list($headers, $body) = explode("\r\n\r\n", $result, 2);
                     $statusCode = curl_getinfo($handle, CURLINFO_HTTP_CODE);
-                    $responseCollection[] = new Response($statusCode, $headers, $body);
+                    $responseCollection[] = new Response($statusCode, $headers, $body, $token);
                     curl_multi_remove_handle($mh, $handle);
                 }
             } while ($running);

--- a/src/Client.php
+++ b/src/Client.php
@@ -74,32 +74,29 @@ class Client
 
             curl_setopt_array($ch, $request->getOptions());
             curl_setopt($ch, CURLOPT_HTTPHEADER, $request->getDecoratedHeaders());
-
-            curl_multi_add_handle($mh, $ch);
         }
 
-        $active = null;
-        do {
-            $mrc = curl_multi_exec($mh, $active);
-        } while ($mrc == CURLM_CALL_MULTI_PERFORM);
-
-        while ($active && $mrc == CURLM_OK) {
-            if (curl_multi_select($mh) == -1) {
-                usleep(1);
+        $handleChunks = array_chunk($handles, 10);
+        foreach ($handleChunks as $handleChunk) {
+            foreach ($handleChunk as $handle) {
+                curl_multi_add_handle($mh, $handle);   
             }
+
+            $running = null;
             do {
-                $mrc = curl_multi_exec($mh, $active);
-            } while ($mrc == CURLM_CALL_MULTI_PERFORM);
-        }
+                while(($execrun = curl_multi_exec($mh, $running)) == CURLM_CALL_MULTI_PERFORM);
 
-        $responseCollection = [];
-        foreach ($handles as $handle) {
-            curl_multi_remove_handle($mh, $handle);
-            $result = curl_multi_getcontent($handle);
+                while($done = curl_multi_info_read($mh)) {
+                    $handle = $done['handle'];
 
-            list($headers, $body) = explode("\r\n\r\n", $result, 2);
-            $statusCode = curl_getinfo($handle, CURLINFO_HTTP_CODE);
-            $responseCollection[] = new Response($statusCode, $headers, $body);
+                    $result = curl_multi_getcontent($handle);
+
+                    list($headers, $body) = explode("\r\n\r\n", $result, 2);
+                    $statusCode = curl_getinfo($handle, CURLINFO_HTTP_CODE);
+                    $responseCollection[] = new Response($statusCode, $headers, $body);
+                    curl_multi_remove_handle($mh, $handle);
+                }
+            } while ($running);
         }
 
         curl_multi_close($mh);

--- a/src/Response.php
+++ b/src/Response.php
@@ -113,6 +113,13 @@ class Response implements ApnsResponseInterface
     private $apnsId;
 
     /**
+     * Device token.
+     *
+     * @var string|null
+     */
+    private $deviceToken;
+
+    /**
      * Response status code.
      *
      * @var int
@@ -182,6 +189,16 @@ class Response implements ApnsResponseInterface
     public function getApnsId()
     {
         return $this->apnsId;
+    }
+
+    /**
+     * Get device token
+     *
+     * @return string|null
+     */
+    public function getDeviceToken()
+    {
+        return $this->deviceToken;
     }
 
     /**

--- a/src/Response.php
+++ b/src/Response.php
@@ -139,12 +139,14 @@ class Response implements ApnsResponseInterface
      * @param int $statusCode
      * @param string $headers
      * @param string $body
+     * @param string $deviceToken
      */
-    public function __construct(int $statusCode, string $headers, string $body)
+    public function __construct(int $statusCode, string $headers, string $body, string $deviceToken = null)
     {
         $this->statusCode = $statusCode;
         $this->apnsId = self::fetchApnsId($headers);
         $this->errorReason = self::fetchErrorReason($body);
+        $this->deviceToken = $deviceToken;
     }
 
     /**


### PR DESCRIPTION
I made a different solution for that problem. As commented in the other pull request: It is tested with sending up to 11.000 notifications.
The solution sends the requests in chunks of 10 requests and waits till a chunk is finished before starting the next one. This solution is slower but does not have the problem with the abort condition.

I think it is not a good idea to use the device token as key for the returned array of responses. Most people who start to using this library want to test the performance of it and send push notifications to a number of device tokens, like i did as well. But it is not possible to test that performance with your real customer device tokens. So you need to push multiple notifications to a single device token. I spammed my device with the 11k notifications. You get some 429 from the Apple Server (~1 per 1000 requests on same device token) but it is totaly fine to discover the performance of the library and your server.
To enable this i set the device token as a property of the response.