### PR TITLE
Remove unnecessary assignation

### DIFF
--- a/README.md
+++ b/README.md
@@ -66,10 +66,10 @@ $alert = $alert->setBody('First push notification');
 $payload = Payload::create()->setAlert($alert);
 
 //set notification sound to default
-$payload = $payload->setSound('default');
+$payload->setSound('default');
 
 //add custom value to your notification, needs to be customized
-$payload = $payload->setCustomValue('key', 'value');
+$payload->setCustomValue('key', 'value');
 
 $deviceTokens = ['<device_token_1>', '<device_token_2>', '<device_token_3>'];
 


### PR DESCRIPTION
These unnecessary assignation in the example may mislead people to think that Payload is immutable and returns a copy instead of modifying itself.