### PR TITLE
On success response there is no body.

### DIFF
--- a/src/Client.php
+++ b/src/Client.php
@@ -119,7 +119,16 @@ class Client
                 // find out which token the response is about
                 $token = curl_getinfo($handle, CURLINFO_PRIVATE);
 
-                list($headers, $body) = explode("\r\n\r\n", $result, 2);
+                $responseParts = explode("\r\n\r\n", $result, 2);
+                $headers = '';
+                $body = '';
+                if (isset($responseParts[0])) {
+                    $headers = $responseParts[0];
+                }
+                if (isset($responseParts[1])) {
+                    $body = $responseParts[1];
+                }
+                
                 $statusCode = curl_getinfo($handle, CURLINFO_HTTP_CODE);
                 $responseCollection[] = new Response($statusCode, $headers, $body, $token);
                 curl_multi_remove_handle($mh, $handle);


### PR DESCRIPTION
This fixes:
Fatal Error (E_ERROR): Uncaught Symfony\Component\Debug\Exception\FatalThrowableError: Type error: Argument 3 passed to Pushok\Response::__construct() must be of the type string, null given, called in edamov/pushok/src/Client.php on line 124 in edamov/pushok/src/Response.php:144

https://developer.apple.com/library/archive/documentation/NetworkingInternet/Conceptual/RemoteNotificationsPG/CommunicatingwithAPNs.html

> For a successful request, the body of the response is empty.