### PR TITLE
Update response object to return status 410 timestamp

### DIFF
--- a/src/ApnsResponseInterface.php
+++ b/src/ApnsResponseInterface.php
@@ -51,4 +51,11 @@ interface ApnsResponseInterface
      * @return string
      */
     public function getErrorDescription(): string;
+
+    /**
+     * Get timestamp for a status 410 error
+     *
+     * @return string
+     */
+    public function get410Timestamp(): string;
 }

--- a/src/Response.php
+++ b/src/Response.php
@@ -134,6 +134,13 @@ class Response implements ApnsResponseInterface
     private $errorReason;
 
     /**
+     * Timestamp for a 410 error
+     *
+     * @var string
+     */
+    private $error410Timestamp;
+
+    /**
      * Response constructor.
      *
      * @param int $statusCode
@@ -146,6 +153,7 @@ class Response implements ApnsResponseInterface
         $this->statusCode = $statusCode;
         $this->apnsId = self::fetchApnsId($headers);
         $this->errorReason = self::fetchErrorReason($body);
+        $this->error410Timestamp = self::fetch410Timestamp($statusCode, $body);
         $this->deviceToken = $deviceToken;
     }
 
@@ -181,6 +189,22 @@ class Response implements ApnsResponseInterface
     private static function fetchErrorReason(string $body): string
     {
         return json_decode($body, true)['reason'] ?: '';
+    }
+
+    /**
+     * Fetch timestamp for a 410 error.
+     * https://developer.apple.com/documentation/usernotifications/setting_up_a_remote_notification_server/sending_notification_requests_to_apns#2947616
+     *
+     * @param int $statusCode
+     * @param string $body
+     * @return string
+     */
+    private static function fetch410Timestamp(int $statusCode, string $body): string
+    {
+        if($statusCode === 410) {
+            return (string)(json_decode($body, true)['timestamp'] ?: '');
+        }
+        return '';
     }
 
     /**
@@ -245,5 +269,15 @@ class Response implements ApnsResponseInterface
         }
 
         return '';
+    }
+
+    /**
+     * Get timestamp for a status 410 error
+     *
+     * @return string
+     */
+    public function get410Timestamp(): string
+    {
+        return $this->error410Timestamp;
     }
 }

--- a/src/Response.php
+++ b/src/Response.php
@@ -174,7 +174,7 @@ class Response implements ApnsResponseInterface
                 continue;
             }
 
-            return $middle[1];
+            return trim($middle[1]);
         }
 
         return '';

--- a/tests/ResponseTest.php
+++ b/tests/ResponseTest.php
@@ -50,4 +50,18 @@ class ResponseTest extends TestCase
 
         $this->assertEquals('The collapse identifier exceeds the maximum allowed size', $response->getErrorDescription());
     }
+
+    public function testGetError410Timestamp()
+    {
+        $response = new Response(410, 'headers', '{"reason": "Unregistered", "timestamp": 1514808000}');
+
+        $this->assertEquals('1514808000', $response->get410Timestamp());
+    }
+
+    public function testGetError410TimestampFailure()
+    {
+        $response = new Response(400, 'headers', '{"reason": "BadCollapseId"}');
+
+        $this->assertEquals('', $response->get410Timestamp());
+    }
 }


### PR DESCRIPTION
To allow access to the timestamp that is returned in a 410 response, as show in the apple documentation.

https://developer.apple.com/documentation/usernotifications/setting_up_a_remote_notification_server/sending_notification_requests_to_apns#2947616