### PR TITLE
Fix for dropped notifications

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,16 +1,23 @@
 language: php
+dist: xenial
 
 php:
+<<<<<<< HEAD
+  - 7.1
+  - 7.2
+  - 7.3
+=======
 - 7.1
+- 7.2
+- 7.3
+>>>>>>> fa00587... Update .travis.yml (#51)
 
-sudo: required
-
-services:
-- docker
-
-before_install:
-- docker pull edamov/pushok-docker
+before_script:
+  - composer install --no-interaction --prefer-dist
 
 script:
-- docker run --name=php7.1 -e TRAVIS=true -e TRAVIS_JOB_ID="${TRAVIS_JOB_ID}" -d -v /home/travis/build/edamov/pushok:/home/pushok edamov/pushok-docker tail -f /dev/null
-- docker exec -t php7.1 /bin/sh -c "cd /home/pushok && php /composer.phar update ${COMPOSER_FLAGS} --no-interaction --prefer-dist && /home/pushok/vendor/bin/phpunit --coverage-clover /home/pushok/build/logs/clover.xml && php /home/pushok/vendor/bin/php-coveralls -v"
+  - mkdir -p build/logs
+  - php vendor/bin/phpunit -c phpunit.xml.dist --coverage-clover build/logs/clover.xml
+
+after_success:
+  - travis_retry php vendor/bin/php-coveralls -v

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,16 +1,17 @@
 language: php
+dist: xenial
 
 php:
-- 7.1
+  - 7.1
+  - 7.2
+  - 7.3
 
-sudo: required
-
-services:
-- docker
-
-before_install:
-- docker pull edamov/pushok-docker
+before_script:
+  - composer install --no-interaction --prefer-dist
 
 script:
-- docker run --name=php7.1 -e TRAVIS=true -e TRAVIS_JOB_ID="${TRAVIS_JOB_ID}" -d -v /home/travis/build/edamov/pushok:/home/pushok edamov/pushok-docker tail -f /dev/null
-- docker exec -t php7.1 /bin/sh -c "cd /home/pushok && php /composer.phar update ${COMPOSER_FLAGS} --no-interaction --prefer-dist && /home/pushok/vendor/bin/phpunit --coverage-clover /home/pushok/build/logs/clover.xml && php /home/pushok/vendor/bin/php-coveralls -v"
+  - mkdir -p build/logs
+  - php vendor/bin/phpunit -c phpunit.xml.dist --coverage-clover build/logs/clover.xml
+
+after_success:
+  - travis_retry php vendor/bin/php-coveralls -v

--- a/composer.json
+++ b/composer.json
@@ -31,9 +31,9 @@
     },
     "require-dev": {
         "ext-xdebug": "*",
-        "phpunit/phpunit" : "~4.0||~5.0",
+        "phpunit/phpunit" : "~6.0 || ~7.0",
         "squizlabs/php_codesniffer": "^2.3",
-        "satooshi/php-coveralls": "^2.0"
+        "php-coveralls/php-coveralls": "^2.0"
     },
     "autoload": {
         "psr-4": {

--- a/phpunit.xml.dist
+++ b/phpunit.xml.dist
@@ -22,7 +22,7 @@
     <logging>
         <log type="tap" target="build/report.tap"/>
         <log type="junit" target="build/report.junit.xml"/>
-        <log type="coverage-html" target="build/coverage" charset="UTF-8" yui="true" highlight="true"/>
+        <log type="coverage-html" target="build/coverage"/>
         <log type="coverage-text" target="build/coverage.txt"/>
         <log type="coverage-clover" target="build/logs/clover.xml"/>
     </logging>

--- a/src/Client.php
+++ b/src/Client.php
@@ -113,7 +113,7 @@ class Client
         while ($running > 0 && $execrun === CURLM_OK) {
             // Block until data is available
             $select_fd = curl_multi_select($mh);
-            // If select returns -1 while running, wait 1 millisecond before continuing
+            // If select returns -1 while running, wait 250 microseconds before continuing
             // Using curl_multi_timeout would be better but it isn't available in PHP yet
             // https://php.net/manual/en/function.curl-multi-select.php#115381
             if ($running && $select_fd === -1) {


### PR DESCRIPTION
This fixes #35.

I have experienced the same issue in #35 where not all of my notifications were sent when I send hundreds of payloads at once. The issue report was cryptic though, and I investigated further to find out why that code sample posted by lipflip fixes the issue.

This problem is documented [here](https://php.net/manual/en/function.curl-multi-select.php#115381) and [here](https://bugs.php.net/bug.php?id=61141). I am not a cURL expert but it seems that `curl_multi_exec` and `curl_multi_select` can unexpectedly return -1 if the function is called while cURL is doing something that can't be described to an application. This is more likely to happen when there are many handles waiting on the stack (or in other words, many notifications waiting to be sent.)

The only way to fix this is to wait for an arbitrary time and then try calling `curl_multi_exec` again. This is the solution that the PHP developers suggest, and it is also [what the popular HTTP library Guzzle does](https://github.com/guzzle/guzzle/blob/003757426cdd50fbad1c34cdbcc8a55f70a4fe8b/src/Handler/CurlMultiHandler.php#L100).

To make the code more readable and easier to debug, I broke the large sending loop in Client.php into smaller loops and added comments. As an added benefit, this change should make pushok more efficient by blocking on `curl_multi_select` instead of eating CPU cycles in a loop. I also fixed running tests on PHP 7.2 so that I could run the test suite for this PR.

To test this pull request, I setup [a mock APNS server](https://github.com/CleverTap/go-apns-server) on Amazon EC2 and sent 50,000 notification payloads in groups of 5,000 at a time. After confirming that it worked, I then tested on APNS Production servers with 50 notification payloads. No notifications were dropped.
