### PR TITLE
Ability to use private key content instead of file path

### DIFF
--- a/tests/AuthProvider/TokenTest.php
+++ b/tests/AuthProvider/TokenTest.php
@@ -19,10 +19,34 @@ class TokenTest extends TestCase
 {
     public function testCreatingTokenAuthProvider()
     {
-        $authProvider = AuthProvider\Token::create($this->getOptions());
+        $options = $this->getOptions();
+        $options['private_key_path'] = __DIR__ . '/../files/private_key.p8';
+        $authProvider = AuthProvider\Token::create($options);
 
         $this->assertInstanceOf(AuthProviderInterface::class, $authProvider);
         $this->assertTrue(is_string($authProvider->get()));
+    }
+
+    public function testCreatingTokenAuthProviderWithKeyContent()
+    {
+        $options = $this->getOptions();
+        $options['private_key_content'] = <<<EOT
+-----BEGIN PRIVATE KEY-----
+MIGTAgEAMBMGByqGSM49AgEGCCqGSM49AwEHBHkwdwIBAQQg13n3isfsEktzl+CtH5ECpRrKk+40prVuCbldkP77gamgCgYIKoZIzj0DAQehRANCAARhwgxSRqXBt54BWRQXoU/doFWULOWrER3uLS43/iugDW1PMDliQZEzWetYAdf+Mafq/PrlbEAfA+l7JfmijAsv
+-----END PRIVATE KEY-----
+EOT;
+        $authProvider = AuthProvider\Token::create($options);
+
+        $this->assertInstanceOf(AuthProviderInterface::class, $authProvider);
+        $this->assertTrue(is_string($authProvider->get()));
+    }
+
+    public function testCreatingTokenAuthProviderWithoutKey()
+    {
+        $this->expectException(\InvalidArgumentException::class);
+
+        $options = $this->getOptions();
+        AuthProvider\Token::create($options);
     }
 
     public function testUseExistingToken()
@@ -30,14 +54,7 @@ class TokenTest extends TestCase
         $token = 'eyJhbGciOiJFUzI1NiIsImtpZCI6IjEyMzQ1Njc4OTAifQ.eyJpc3MiOiIxMjM0NTY3ODkwIiwiaWF0IjoxNDc4NTE0NDk4fQ.' .
             'YxR8Hw--Hp8YH8RF2QDiwOjmGhTC_7g2DpbnzKQZ8Sj20-q12LrLrAMafcuxf97CTHl9hCVere0vYrzcLmGV-A';
 
-        $options = [
-            'key_id' => '1234567890',
-            'team_id' => '1234567890',
-            'app_bundle_id' => 'com.app.Test',
-            'private_key_path' => __DIR__ . '../files/private_key.p8',
-            'private_key_secret' => null
-        ];
-
+        $options = $this->getOptions();
         $authProvider = AuthProvider\Token::useExisting($token, $options);
 
         $this->assertInstanceOf(AuthProviderInterface::class, $authProvider);
@@ -50,8 +67,6 @@ class TokenTest extends TestCase
             'key_id' => '1234567890',
             'team_id' => '1234567890',
             'app_bundle_id' => 'com.app.Test',
-            'private_key_path' => __DIR__ . '/../files/private_key.p8',
-            'private_key_secret' => null
         ];
     }
 }


### PR DESCRIPTION
Hi @edamov,
First of all, thank you for the library!

I suggest adding the ability to use a private key as a string instead of a file.
In my case, I don't want to ship it in a separate file but hardcode in the PHP script.
I think it could be also helpful in other cases, e.g. when secrets are stored in a remote registry or environment.
Backward compatibility is preserved.