### PR TITLE
replace array_merge by array_replace

### DIFF
--- a/src/Request.php
+++ b/src/Request.php
@@ -130,7 +130,7 @@ class Request
      */
     public function addOptions(array $options)
     {
-        $this->options = array_merge($this->options, $options);
+        $this->options = array_replace($this->options, $options);
     }
 
     /**


### PR DESCRIPTION
Hello @edamov , there were a bug on my previous pull request.

array_merge reorganized the option keys, array_replace must preserve them