### PR TITLE
APNS Topic Support for Certificate Integrations

### DIFF
--- a/src/AuthProvider/Certificate.php
+++ b/src/AuthProvider/Certificate.php
@@ -37,6 +37,13 @@ class Certificate implements AuthProviderInterface
     private $certificateSecret;
 
     /**
+     * The bundle ID for app obtained from Apple developer account.
+     *
+     * @var string
+     */
+    private $appBundleId;
+
+    /**
      * This provider accepts the following options:
      *
      * - certificate_path
@@ -48,6 +55,7 @@ class Certificate implements AuthProviderInterface
     {
         $this->certificatePath   = $options['certificate_path'] ;
         $this->certificateSecret = $options['certificate_secret'];
+        $this->appBundleId       = $options['app_bundle_id'] ?? null;
     }
 
     /**
@@ -75,5 +83,8 @@ class Certificate implements AuthProviderInterface
                 CURLOPT_SSL_VERIFYPEER => true
             ]
         );
+        $request->addHeaders([
+            "apns-topic" => $this->appBundleId
+        ]);
     }
 }

--- a/tests/AuthProvider/CertificateTest.php
+++ b/tests/AuthProvider/CertificateTest.php
@@ -26,4 +26,15 @@ class CertificateTest extends TestCase
 
         $this->assertInstanceOf(AuthProviderInterface::class, $authProvider);
     }
+
+    public function testCreatingCertificateAuthProviderWithAppBundleId()
+    {
+        $options = [];
+        $options['certificate_path'] = __DIR__ . '/../files/certificate.pem';
+        $options['certificate_secret'] = 'secret';
+        $options['appBundleId'] = 'com.apple.test';
+        $authProvider = AuthProvider\Certificate::create($options);
+
+        $this->assertInstanceOf(AuthProviderInterface::class, $authProvider);
+    }
 }


### PR DESCRIPTION
Adds support for setting the APNS topic for certificate integrations. Without this, you will get the following error consistently when attempting to using certain certificates:

```
The apns-topic header of the request was not specified and was required. The apns-topic header is mandatory when the client is connected using a certificate that supports multiple topics.
```

Additional documentation for this can be found at https://developer.apple.com/library/archive/documentation/NetworkingInternet/Conceptual/RemoteNotificationsPG/CommunicatingwithAPNs.html.