### PR TITLE
New Header to support iOS 13

### DIFF
--- a/src/Request.php
+++ b/src/Request.php
@@ -29,6 +29,7 @@ class Request
     const HEADER_APNS_PRIORITY = 'apns-priority';
     const HEADER_APNS_TOPIC = 'apns-topic';
     const HEADER_APNS_COLLAPSE_ID = 'apns-collapse-id';
+    const HEADER_APNS_PUSH_TYPE = 'apns-push-type';
 
     /**
      * Request headers.
@@ -227,10 +228,20 @@ class Request
 
         if (is_int($notification->getPriority())) {
             $this->headers[self::HEADER_APNS_PRIORITY] =  $notification->getPriority();
+        } else if ($notification->getPayload()->isContentAvailable()) {
+            $this->headers[self::HEADER_APNS_PRIORITY] = Notification::PRIORITY_LOW;
         }
 
         if (!empty($notification->getCollapseId())) {
             $this->headers[self::HEADER_APNS_COLLAPSE_ID ] = $notification->getCollapseId();
+        }
+        
+        // new header required to support iOS 13
+        
+        $this->headers[self::HEADER_APNS_PUSH_TYPE] = 'alert';
+        
+        if ($notification->getPayload()->isContentAvailable()) {
+            $this->headers[self::HEADER_APNS_PUSH_TYPE] = 'background';
         }
     }
 }


### PR DESCRIPTION
As found in the documentation at https://developer.apple.com/documentation/usernotifications/setting_up_a_remote_notification_server/sending_notification_requests_to_apns

A new header with the name `apns-push-type` has to be sent for devices running iOS 13. The possible values are `alert` for normal notifications and `background` for `content-available` notifications.

While at it I fixed the `apns-priority` header value for `content-available` notifications which should be 5 or less according to the documentation, while still allowing for an arbitrary number to be specified if the user wants to.