### PR TITLE
Change APS Type From Array To Object

### DIFF
--- a/src/Payload.php
+++ b/src/Payload.php
@@ -309,7 +309,7 @@ class Payload implements \JsonSerializable
      */
     public function toJson(): string
     {
-        return json_encode($this, JSON_UNESCAPED_UNICODE | JSON_FORCE_OBJECT);
+        return json_encode($this, JSON_UNESCAPED_UNICODE);
     }
 
     /**
@@ -323,31 +323,31 @@ class Payload implements \JsonSerializable
         $payload = self::getDefaultPayloadStructure();
 
         if ($this->alert instanceof Alert || is_string($this->alert)) {
-            $payload[self::PAYLOAD_ROOT_KEY][self::PAYLOAD_ALERT_KEY] = $this->alert;
+            $payload[self::PAYLOAD_ROOT_KEY]->{self::PAYLOAD_ALERT_KEY} = $this->alert;
         }
 
         if (is_int($this->badge)) {
-            $payload[self::PAYLOAD_ROOT_KEY][self::PAYLOAD_BADGE_KEY] = $this->badge;
+            $payload[self::PAYLOAD_ROOT_KEY]->{self::PAYLOAD_BADGE_KEY} = $this->badge;
         }
 
         if (is_string($this->sound)) {
-            $payload[self::PAYLOAD_ROOT_KEY][self::PAYLOAD_SOUND_KEY] = $this->sound;
+            $payload[self::PAYLOAD_ROOT_KEY]->{self::PAYLOAD_SOUND_KEY} = $this->sound;
         }
 
         if (is_bool($this->contentAvailable)) {
-            $payload[self::PAYLOAD_ROOT_KEY][self::PAYLOAD_CONTENT_AVAILABLE_KEY] = (int)$this->contentAvailable;
+            $payload[self::PAYLOAD_ROOT_KEY]->{self::PAYLOAD_CONTENT_AVAILABLE_KEY} = (int)$this->contentAvailable;
         }
 
         if (is_bool($this->mutableContent)) {
-            $payload[self::PAYLOAD_ROOT_KEY][self::PAYLOAD_MUTABLE_CONTENT_KEY] = (int)$this->mutableContent;
+            $payload[self::PAYLOAD_ROOT_KEY]->{self::PAYLOAD_MUTABLE_CONTENT_KEY} = (int)$this->mutableContent;
         }
 
         if (is_string($this->category)) {
-            $payload[self::PAYLOAD_ROOT_KEY][self::PAYLOAD_CATEGORY_KEY] = $this->category;
+            $payload[self::PAYLOAD_ROOT_KEY]->{self::PAYLOAD_CATEGORY_KEY} = $this->category;
         }
 
         if (is_string($this->threadId)) {
-            $payload[self::PAYLOAD_ROOT_KEY][self::PAYLOAD_THREAD_ID_KEY] = $this->threadId;
+            $payload[self::PAYLOAD_ROOT_KEY]->{self::PAYLOAD_THREAD_ID_KEY} = $this->threadId;
         }
 
         if ((is_array($this->customValues) || $this->customValues instanceof Countable) && count($this->customValues)) {
@@ -364,6 +364,6 @@ class Payload implements \JsonSerializable
      */
     private static function getDefaultPayloadStructure()
     {
-        return [self::PAYLOAD_ROOT_KEY => []];
+        return [self::PAYLOAD_ROOT_KEY => new \stdClass];
     }
 }

--- a/tests/PayloadTest.php
+++ b/tests/PayloadTest.php
@@ -76,8 +76,8 @@ class PayloadTest extends TestCase
 
     public function testConvertToJSon()
     {
-        $alert = Alert::create()->setTitle('title');
 
+        $alert = Alert::create()->setTitle('title');
         $payload = Payload::create()
             ->setAlert($alert)
             ->setBadge(1)
@@ -93,5 +93,15 @@ class PayloadTest extends TestCase
             ' "thread-id": "tread-id", "mutable-content": 1, "content-available": 1}, "key": "value"}',
             $payload->toJson()
         );
+
+    }
+
+    public function testSetCustomArrayType() {
+        $alert = Alert::create()->setTitle('title');
+        $payload = Payload::create()
+            ->setAlert($alert)
+            ->setCustomValue('array', array(1,2,3));
+
+        $this->assertEquals(gettype(json_decode($payload->toJson())->array), 'array');
     }
 }


### PR DESCRIPTION
As written in https://github.com/edamov/pushok/issues/82 the library used the `JSON_FORCE_OBJECT` constant in the `Payload::toJson()` method. This used to make non-associative array to be outputed as objects

I removed the `JSON_FORCE_OBJECT` option and kept the `JSON_UNESCAPED_UNICODE`.

Changing the type of the APS key  to object in `Payload::getDefaultPayloadStructure()` was enough to make sure the key is always outputed as an object in the json.