### PR TITLE
Set a correct apns-topic value based on a push type

### DIFF
--- a/src/AuthProvider/Certificate.php
+++ b/src/AuthProvider/Certificate.php
@@ -102,11 +102,11 @@ class Certificate implements AuthProviderInterface
                 break;
 
             case 'complication':
-                return $this->appBundleId = '.complication';
+                return $this->appBundleId . '.complication';
                 break;
 
             case 'fileprovider':
-                return $this->appBundleId = '.pushkit.fileprovider';
+                return $this->appBundleId . '.pushkit.fileprovider';
                 break;
 
             default:

--- a/src/AuthProvider/Certificate.php
+++ b/src/AuthProvider/Certificate.php
@@ -99,19 +99,15 @@ class Certificate implements AuthProviderInterface
         switch ($pushType) {
             case 'voip':
                 return $this->appBundleId . '.voip';
-                break;
 
             case 'complication':
                 return $this->appBundleId . '.complication';
-                break;
 
             case 'fileprovider':
                 return $this->appBundleId . '.pushkit.fileprovider';
-                break;
 
             default:
                 return $this->appBundleId;
-                break;
         }
     }
 }

--- a/src/AuthProvider/Certificate.php
+++ b/src/AuthProvider/Certificate.php
@@ -84,7 +84,34 @@ class Certificate implements AuthProviderInterface
             ]
         );
         $request->addHeaders([
-            "apns-topic" => $this->appBundleId
+            'apns-topic' => $this->generateApnsTopic($request->getHeaders()['apns-push-type']),
         ]);
+    }
+
+    /**
+     * Generate a correct apns-topic string
+     *
+     * @param string $pushType
+     * @return string
+     */
+    public function generateApnsTopic(string $pushType)
+    {
+        switch ($pushType) {
+            case 'voip':
+                return $this->appBundleId . '.voip';
+                break;
+
+            case 'complication':
+                return $this->appBundleId = '.complication';
+                break;
+
+            case 'complication':
+                return $this->appBundleId = '.pushkit.fileprovider';
+                break;
+
+            default:
+                return $this->appBundleId;
+                break;
+        }
     }
 }

--- a/src/AuthProvider/Certificate.php
+++ b/src/AuthProvider/Certificate.php
@@ -105,7 +105,7 @@ class Certificate implements AuthProviderInterface
                 return $this->appBundleId = '.complication';
                 break;
 
-            case 'complication':
+            case 'fileprovider':
                 return $this->appBundleId = '.pushkit.fileprovider';
                 break;
 

--- a/src/AuthProvider/Token.php
+++ b/src/AuthProvider/Token.php
@@ -136,9 +136,36 @@ class Token implements AuthProviderInterface
     public function authenticateClient(Request $request)
     {
         $request->addHeaders([
-            "apns-topic" => $this->appBundleId,
-            'Authorization' => 'bearer ' . $this->token
+            'apns-topic' => $this->generateApnsTopic($request->getHeaders()['apns-push-type']),
+            'Authorization' => 'bearer ' . $this->token,
         ]);
+    }
+
+    /**
+     * Generate a correct apns-topic string
+     *
+     * @param string $pushType
+     * @return string
+     */
+    public function generateApnsTopic(string $pushType)
+    {
+        switch ($pushType) {
+            case 'voip':
+                return $this->appBundleId . '.voip';
+                break;
+
+            case 'complication':
+                return $this->appBundleId = '.complication';
+                break;
+
+            case 'complication':
+                return $this->appBundleId = '.pushkit.fileprovider';
+                break;
+
+            default:
+                return $this->appBundleId;
+                break;
+        }
     }
 
     /**

--- a/src/AuthProvider/Token.php
+++ b/src/AuthProvider/Token.php
@@ -158,7 +158,7 @@ class Token implements AuthProviderInterface
                 return $this->appBundleId = '.complication';
                 break;
 
-            case 'complication':
+            case 'fileprovider':
                 return $this->appBundleId = '.pushkit.fileprovider';
                 break;
 

--- a/src/AuthProvider/Token.php
+++ b/src/AuthProvider/Token.php
@@ -152,19 +152,15 @@ class Token implements AuthProviderInterface
         switch ($pushType) {
             case 'voip':
                 return $this->appBundleId . '.voip';
-                break;
 
             case 'complication':
                 return $this->appBundleId . '.complication';
-                break;
 
             case 'fileprovider':
                 return $this->appBundleId . '.pushkit.fileprovider';
-                break;
 
             default:
                 return $this->appBundleId;
-                break;
         }
     }
 

--- a/src/AuthProvider/Token.php
+++ b/src/AuthProvider/Token.php
@@ -155,11 +155,11 @@ class Token implements AuthProviderInterface
                 break;
 
             case 'complication':
-                return $this->appBundleId = '.complication';
+                return $this->appBundleId . '.complication';
                 break;
 
             case 'fileprovider':
-                return $this->appBundleId = '.pushkit.fileprovider';
+                return $this->appBundleId . '.pushkit.fileprovider';
                 break;
 
             default:

--- a/tests/AuthProvider/TokenTest.php
+++ b/tests/AuthProvider/TokenTest.php
@@ -12,19 +12,89 @@
 namespace Pushok\AuthProvider;
 
 use PHPUnit\Framework\TestCase;
-use Pushok\AuthProvider;
 use Pushok\AuthProviderInterface;
+use Pushok\Notification;
+use Pushok\Payload;
+use Pushok\Request;
 
 class TokenTest extends TestCase
 {
-    public function testCreatingTokenAuthProvider()
+    public function testCreatingTokenAuthProviderWithKeyPath()
     {
         $options = $this->getOptions();
         $options['private_key_path'] = __DIR__ . '/../files/private_key.p8';
-        $authProvider = AuthProvider\Token::create($options);
+        $authProvider = Token::create($options);
 
         $this->assertInstanceOf(AuthProviderInterface::class, $authProvider);
         $this->assertTrue(is_string($authProvider->get()));
+    }
+
+    public function testCreatingTokenAuthProviderWithKeyContent()
+    {
+        $options = $this->getOptions();
+        $options['private_key_content'] = file_get_contents(
+            implode(DIRECTORY_SEPARATOR, [__DIR__, '..', 'files', 'private_key.p8'])
+        );
+        $authProvider = Token::create($options);
+
+        $this->assertInstanceOf(AuthProviderInterface::class, $authProvider);
+        $this->assertTrue(is_string($authProvider->get()));
+    }
+
+    public function testCreatingTokenAuthProviderWithoutKey()
+    {
+        $this->expectException(\InvalidArgumentException::class);
+
+        $options = $this->getOptions();
+        Token::create($options);
+    }
+
+    public function testUseExistingToken()
+    {
+        $token = 'eyJhbGciOiJFUzI1NiIsImtpZCI6IjEyMzQ1Njc4OTAifQ.eyJpc3MiOiIxMjM0NTY3ODkwIiwiaWF0IjoxNDc4NTE0NDk4fQ.' .
+            'YxR8Hw--Hp8YH8RF2QDiwOjmGhTC_7g2DpbnzKQZ8Sj20-q12LrLrAMafcuxf97CTHl9hCVere0vYrzcLmGV-A';
+
+        $options = $this->getOptions();
+        $authProvider = Token::useExisting($token, $options);
+
+        $this->assertInstanceOf(AuthProviderInterface::class, $authProvider);
+        $this->assertEquals($token, $authProvider->get());
+    }
+
+    public function testVoipApnsTopic()
+    {
+        $options = $this->getOptions();
+        $options['private_key_path'] = __DIR__ . '/../files/private_key.p8';
+        $authProvider = Token::create($options);
+
+        $request = $this->createRequest('voip');
+        $authProvider->authenticateClient($request);
+
+        $this->assertSame($request->getHeaders()['apns-topic'], $options['app_bundle_id'] . '.voip');
+    }
+
+    public function testComplicationApnsTopic()
+    {
+        $options = $this->getOptions();
+        $options['private_key_path'] = __DIR__ . '/../files/private_key.p8';
+        $authProvider = Token::create($options);
+
+        $request = $this->createRequest('complication');
+        $authProvider->authenticateClient($request);
+
+        $this->assertSame($request->getHeaders()['apns-topic'], $options['app_bundle_id'] . '.complication');
+    }
+
+    public function testFileproviderApnsTopic()
+    {
+        $options = $this->getOptions();
+        $options['private_key_path'] = __DIR__ . '/../files/private_key.p8';
+        $authProvider = Token::create($options);
+
+        $request = $this->createRequest('fileprovider');
+        $authProvider->authenticateClient($request);
+
+        $this->assertSame($request->getHeaders()['apns-topic'], $options['app_bundle_id'] . '.pushkit.fileprovider');
     }
 
     private function getOptions()
@@ -36,37 +106,11 @@ class TokenTest extends TestCase
         ];
     }
 
-    public function testCreatingTokenAuthProviderWithKeyContent()
+    private function createRequest(string $pushType = 'alert'): Request
     {
-        $options = $this->getOptions();
+        $notification = new Notification(Payload::create()->setPushType($pushType), '123');
+        $request = new Request($notification, $production = false);
 
-        $options['private_key_content'] = file_get_contents(
-            implode(DIRECTORY_SEPARATOR, [__DIR__, '..', 'files', 'private_key.p8'])
-        );
-
-        $authProvider = AuthProvider\Token::create($options);
-
-        $this->assertInstanceOf(AuthProviderInterface::class, $authProvider);
-        $this->assertTrue(is_string($authProvider->get()));
-    }
-
-    public function testCreatingTokenAuthProviderWithoutKey()
-    {
-        $this->expectException(\InvalidArgumentException::class);
-
-        $options = $this->getOptions();
-        AuthProvider\Token::create($options);
-    }
-
-    public function testUseExistingToken()
-    {
-        $token = 'eyJhbGciOiJFUzI1NiIsImtpZCI6IjEyMzQ1Njc4OTAifQ.eyJpc3MiOiIxMjM0NTY3ODkwIiwiaWF0IjoxNDc4NTE0NDk4fQ.' .
-            'YxR8Hw--Hp8YH8RF2QDiwOjmGhTC_7g2DpbnzKQZ8Sj20-q12LrLrAMafcuxf97CTHl9hCVere0vYrzcLmGV-A';
-
-        $options = $this->getOptions();
-        $authProvider = AuthProvider\Token::useExisting($token, $options);
-
-        $this->assertInstanceOf(AuthProviderInterface::class, $authProvider);
-        $this->assertEquals($token, $authProvider->get());
+        return $request;
     }
 }


### PR DESCRIPTION
This PR addresses this issue https://github.com/edamov/pushok/issues/78#issuecomment-596448679

Based on the [APNS documentation](https://developer.apple.com/documentation/usernotifications/setting_up_a_remote_notification_server/sending_notification_requests_to_apns/) we should use different `apns-topic` headers for different push types. Usually just by adding various suffixes to the bundle ID. Without these changes `voip`, `complication` and `fileprovider` don't work.