### PR TITLE
Add Support For Critical Notification Sound

### DIFF
--- a/src/Payload.php
+++ b/src/Payload.php
@@ -13,6 +13,7 @@ namespace Pushok;
 
 use Countable;
 use Pushok\Payload\Alert;
+use Pushok\Payload\Sound;
 
 // Polyfill for PHP 7.2
 if (!function_exists('is_countable')) {
@@ -62,7 +63,7 @@ class Payload implements \JsonSerializable
     /**
      * The name of a sound file in the app bundle or in the Library/Sounds folder of the app’s data container.
      *
-     * @var string
+     * @var Sound|string
      */
     private $sound;
 
@@ -185,13 +186,15 @@ class Payload implements \JsonSerializable
     /**
      * Set sound.
      *
-     * @param string $value
+     * @param Sound|string $sound
      *
      * @return Payload
      */
-    public function setSound(string $value): Payload
+    public function setSound($sound): Payload
     {
-        $this->sound = $value;
+        if ($sound instanceof Sound || is_string($sound)) {
+            $this->sound = $sound;
+        }
 
         return $this;
     }
@@ -380,7 +383,7 @@ class Payload implements \JsonSerializable
             $payload[self::PAYLOAD_ROOT_KEY]->{self::PAYLOAD_BADGE_KEY} = $this->badge;
         }
 
-        if (is_string($this->sound)) {
+        if ($this->sound instanceof Sound || is_string($this->sound)) {
             $payload[self::PAYLOAD_ROOT_KEY]->{self::PAYLOAD_SOUND_KEY} = $this->sound;
         }
 

--- a/src/Payload/Sound.php
+++ b/src/Payload/Sound.php
@@ -1,0 +1,160 @@
+<?php
+
+/*
+ * This file is part of the Pushok package.
+ *
+ * (c) Arthur Edamov <edamov@gmail.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Pushok\Payload;
+
+/**
+ * Class Sound
+ *
+ * @package Pushok\Payload
+ *
+ * @see http://bit.ly/payload-key-reference
+ */
+class Sound implements \JsonSerializable
+{
+    const SOUND_CRITICAL_KEY = 'critical';
+    const SOUND_NAME_KEY = 'name';
+    const SOUND_VOLUME_KEY = 'volume';
+
+    /**
+     * Whether the sound should be played as a critical notification or not
+     *
+     * @var integer
+     */
+    private $critical;
+
+    /**
+     * The sound file name.
+     *
+     * @var string
+     */
+    private $name;
+
+    /**
+     * The sound volume.
+     *
+     * @var float
+     */
+    private $volume;
+
+    protected function __construct()
+    {
+    }
+
+    public static function create()
+    {
+        return new self();
+    }
+
+    /**
+     * Set Sound critical.
+     *
+     * @param int $value
+     * @return Sound
+     */
+    public function setCritical(int $value): Sound
+    {
+        $this->critical = $value;
+
+        return $this;
+    }
+
+    /**
+     * Get Sound critical.
+     *
+     * @return string
+     */
+    public function getCritical()
+    {
+        return $this->critical;
+    }
+
+    /**
+     * Set Sound name.
+     *
+     * @param string $value
+     * @return Sound
+     */
+    public function setName(string $value): Sound
+    {
+        $this->name = $value;
+
+        return $this;
+    }
+
+    /**
+     * Get Sound name.
+     *
+     * @return string
+     */
+    public function getName()
+    {
+        return $this->name;
+    }
+
+    /**
+     * Set Sound volume.
+     *
+     * @param float $value
+     * @return Sound
+     */
+    public function setVolume(float $value): Sound
+    {
+        $this->volume = $value;
+
+        return $this;
+    }
+
+    /**
+     * Get Sound volume.
+     *
+     * @return float
+     */
+    public function getVolume()
+    {
+        return $this->volume;
+    }
+
+    /**
+     * Convert Sound to JSON.
+     *
+     * @return string
+     */
+    public function toJson(): string
+    {
+        return json_encode($this, JSON_UNESCAPED_UNICODE);
+    }
+
+    /**
+     * Specify data which should be serialized to JSON.
+     *
+     * @return array
+     * @link   http://php.net/manual/en/jsonserializable.jsonserialize.php
+     */
+    public function jsonSerialize()
+    {
+        $sound = [];
+
+        if (is_integer($this->critical)) {
+            $sound[self::SOUND_CRITICAL_KEY] = $this->critical;
+        }
+
+        if (is_string($this->name)) {
+            $sound[self::SOUND_NAME_KEY] = $this->name;
+        }
+
+        if (is_float($this->volume)) {
+            $sound[self::SOUND_VOLUME_KEY] = $this->volume;
+        }
+
+        return $sound;
+    }
+}

--- a/tests/Payload/SoundTest.php
+++ b/tests/Payload/SoundTest.php
@@ -1,0 +1,52 @@
+<?php
+
+/*
+ * This file is part of the Pushok package.
+ *
+ * (c) Arthur Edamov <edamov@gmail.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Pushok\Tests\Payload;
+
+use PHPUnit\Framework\TestCase;
+use Pushok\Payload\Sound;
+
+class SoundTest extends TestCase
+{
+    public function testSetCritical()
+    {
+        $sound = Sound::create()->setCritical(1);
+
+        $this->assertEquals(1, $sound->getCritical());
+    }
+
+    public function testSetName()
+    {
+        $sound = Sound::create()->setName('soundName');
+
+        $this->assertEquals('soundName', $sound->getName());
+    }
+
+    public function testSetVolume()
+    {
+        $sound = Sound::create()->setVolume(1.0);
+
+        $this->assertEquals(1.0, $sound->getVolume());
+    }
+
+    public function testSoundConvertingToJson()
+    {
+        $sound = Sound::create()
+            ->setCritical(1)
+            ->setName('soundName')
+            ->setVolume(1.0);
+
+        $this->assertJsonStringEqualsJsonString(
+            '{"critical":1,"name":"soundName","volume":1.0}',
+            $sound->toJson()
+        );
+    }
+}

--- a/tests/PayloadTest.php
+++ b/tests/PayloadTest.php
@@ -15,6 +15,7 @@ use PHPUnit\Framework\TestCase;
 use Pushok\InvalidPayloadException;
 use Pushok\Payload;
 use Pushok\Payload\Alert;
+use Pushok\Payload\Sound;
 
 class PayloadTest extends TestCase
 {
@@ -35,9 +36,10 @@ class PayloadTest extends TestCase
 
     public function testSetSound()
     {
-        $payload = Payload::create()->setSound('soundString');
+        $sound = Sound::create();
+        $payload = Payload::create()->setSound($sound);
 
-        $this->assertEquals('soundString', $payload->getSound());
+        $this->assertSame($sound, $payload->getSound());
     }
 
     public function testSetCategory()
@@ -104,10 +106,11 @@ class PayloadTest extends TestCase
     {
 
         $alert = Alert::create()->setTitle('title');
+        $sound = Sound::create()->setName('soundName')->setCritical(1)->setVolume(1.0);
         $payload = Payload::create()
             ->setAlert($alert)
             ->setBadge(1)
-            ->setSound('sound')
+            ->setSound($sound)
             ->setCategory('category')
             ->setThreadId('tread-id')
             ->setContentAvailability(true)
@@ -115,7 +118,7 @@ class PayloadTest extends TestCase
             ->setCustomValue('key', 'value');
 
         $this->assertJsonStringEqualsJsonString(
-            '{"aps": {"alert": {"title": "title"}, "badge": 1, "sound": "sound", "category": "category", ' .
+            '{"aps": {"alert": {"title": "title"}, "badge": 1, "sound": {"critical": 1, "name": "soundName", "volume": 1.0}, "category": "category", ' .
             ' "thread-id": "tread-id", "mutable-content": 1, "content-available": 1}, "key": "value"}',
             $payload->toJson()
         );


### PR DESCRIPTION
This PR adds support for sending critical notifications (assuming you have the right entitlements from Apple).

The sound attribute on the Payload object now accepts both a string or a Sound object as the payload.

Some validation rules for critical (0, 1) or volume (from 0.0 to 1.0) haven't been implemented but this is a good start and works already in production for me.