### PR TITLE
Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -56,6 +56,8 @@ $options = [
     'private_key_secret' => null // Private key secret
 ];
 
+// Be aware of thing that Token will stale after one hour, so you should generate it again.
+// Can be useful when trying to send pushes during long-running tasks
 $authProvider = AuthProvider\Token::create($options);
 
 $alert = Alert::create()->setTitle('Hello!');


### PR DESCRIPTION
Add info about AuthTokens staling as described in [docs](https://developer.apple.com/library/archive/documentation/NetworkingInternet/Conceptual/RemoteNotificationsPG/CommunicatingwithAPNs.html)

> To ensure security, APNs requires new tokens to be generated periodically. A new token has an updated issued at claim key, whose value indicates the time the token was generated. If the timestamp for token issue is not within the last hour, APNs rejects subsequent push messages, returning an ExpiredProviderToken (403) error.