### PR TITLE
fix: APNs Interface Undefined method "getDeviceToken"

### DIFF
--- a/src/ApnsResponseInterface.php
+++ b/src/ApnsResponseInterface.php
@@ -25,6 +25,13 @@ interface ApnsResponseInterface
     public function getApnsId();
 
     /**
+     * Get device token
+     *
+     * @return string|null
+     */
+    public function getDeviceToken();
+
+    /**
      * Get status code.
      *
      * @return int|null


### PR DESCRIPTION
```
foreach ($responses as $response) {
            // The device token
            $device_token = $response->getDeviceToken();
            ...
```