### PR TITLE
php^8.0 requires return type for jsonSerialize to be of type mixed

### DIFF
--- a/src/Payload/Alert.php
+++ b/src/Payload/Alert.php
@@ -322,10 +322,10 @@ class Alert implements \JsonSerializable
     /**
      * Specify data which should be serialized to JSON.
      *
-     * @return array
+     * @return mixed
      * @link   http://php.net/manual/en/jsonserializable.jsonserialize.php
      */
-    public function jsonSerialize()
+    public function jsonSerialize(): mixed
     {
         $alert = [];
 


### PR DESCRIPTION
I upgraded to php8.1 and now I get a complain about incompatible return type for the `Alert::jsonSerialize` function:

`Fatal Error - During inheritance of JsonSerializable: Uncaught Fuel\Core\PhpErrorException: Return type of Pushok\Payload\Alert::jsonSerialize() should either be compatible with JsonSerializable::jsonSerialize(): mixed, or the #[\ReturnTypeWillChange] attribute should be used to temporarily suppress the notice in /app/vendor/edamov/pushok/src/Payload/Alert.php:328`

For compatibility reasons I added the `mixed` return type to the function declaration.