### PR TITLE
Add return types to jsonSerialize() to be compatible with JsonSerializable::jsonSerialize()

### DIFF
--- a/src/Payload.php
+++ b/src/Payload.php
@@ -424,7 +424,7 @@ class Payload implements \JsonSerializable
      * @return array
      * @link   http://php.net/manual/en/jsonserializable.jsonserialize.php
      */
-    public function jsonSerialize()
+    public function jsonSerialize(): array
     {
         $payload = self::getDefaultPayloadStructure();
 

--- a/src/Payload/Alert.php
+++ b/src/Payload/Alert.php
@@ -325,7 +325,7 @@ class Alert implements \JsonSerializable
      * @return array
      * @link   http://php.net/manual/en/jsonserializable.jsonserialize.php
      */
-    public function jsonSerialize()
+    public function jsonSerialize(): array
     {
         $alert = [];
 

--- a/src/Payload/Sound.php
+++ b/src/Payload/Sound.php
@@ -139,7 +139,7 @@ class Sound implements \JsonSerializable
      * @return array
      * @link   http://php.net/manual/en/jsonserializable.jsonserialize.php
      */
-    public function jsonSerialize()
+    public function jsonSerialize(): array
     {
         $sound = [];
 


### PR DESCRIPTION
This will get rid of deprecation notices like:

 ```
Return type of Pushok\Payload::jsonSerialize()  
should either be compatible with JsonSerializable::jsonSerialize(): mixed, 
or the #[\ReturnTypeWillChange] attribute should be used to temporarily suppress the notice
```

while still following the type that's already specified in the phpdoc block.