### PR TITLE
adds apns topic push-type.liveactivity

### DIFF
--- a/src/AuthProvider/Token.php
+++ b/src/AuthProvider/Token.php
@@ -153,6 +153,9 @@ class Token implements AuthProviderInterface
             case 'voip':
                 return $this->appBundleId . '.voip';
 
+            case 'liveactivity':
+                return $this->appBundleId . '.push-type.liveactivity';
+
             case 'complication':
                 return $this->appBundleId . '.complication';
 


### PR DESCRIPTION
https://developer.apple.com/documentation/usernotifications/setting_up_a_remote_notification_server/sending_notification_requests_to_apns

> If you set this push type, the apns-topic header field must use your app’s bundle ID with the push-type.liveactivity appended to the end.