### PR TITLE
Communicate that 0.15.x is php 8.1+ only

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Pushok
 
-[![PHP >= 7.2](https://img.shields.io/badge/php-%3E%3D%208.0-8892BF.svg?style=flat-square)](https://php.net/)
+[![PHP >= 8.1](https://img.shields.io/badge/php-%3E%3D%208.0-8892BF.svg?style=flat-square)](https://php.net/)
 [![Build Status][ico-travis]][link-travis]
 [![Latest Version on Packagist][ico-version]][link-packagist]
 [![Total Downloads][ico-downloads]][link-downloads]
@@ -24,7 +24,7 @@ Pushok is a simple PHP library for sending push notifications to APNs.
 
 ## Requirements
 
-* PHP >= 8.0
+* PHP >= 8.1
 * lib-curl >= 7.46.0 (with http/2 support enabled)
 * lib-openssl >= 1.0.2e 
 

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Pushok
 
-[![PHP >= 8.1](https://img.shields.io/badge/php-%3E%3D%208.0-8892BF.svg?style=flat-square)](https://php.net/)
+[![PHP >= 8.1](https://img.shields.io/badge/php-%3E%3D%208.1-8892BF.svg?style=flat-square)](https://php.net/)
 [![Build Status][ico-travis]][link-travis]
 [![Latest Version on Packagist][ico-version]][link-packagist]
 [![Total Downloads][ico-downloads]][link-downloads]

--- a/composer.json
+++ b/composer.json
@@ -19,7 +19,7 @@
         }
     ],
     "require": {
-        "php": "^8.0",
+        "php": "^8.1",
         "ext-curl": "*",
         "lib-curl": ">=7.46.0",
         "ext-openssl": "*",


### PR DESCRIPTION
Even dought it wasn't mensionned, 0.15.x is PHP 8.1+ only
Because of transient dependencies, see #166

---

Another PR will introduce a 0.14.3 ; still compatible with PHP 8.0 ; without deprecation warnings as soon as a target branch will exists :)