### PR TITLE
Version 0.14.3 proposal

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Pushok
 
-[![PHP >= 7.2](https://img.shields.io/badge/php-%3E%3D%208.0-8892BF.svg?style=flat-square)](https://php.net/)
+[![PHP >= 8.0](https://img.shields.io/badge/php-%3E%3D%208.0-8892BF.svg?style=flat-square)](https://php.net/)
 [![Build Status][ico-travis]][link-travis]
 [![Latest Version on Packagist][ico-version]][link-packagist]
 [![Total Downloads][ico-downloads]][link-downloads]

--- a/src/Payload.php
+++ b/src/Payload.php
@@ -458,6 +458,7 @@ class Payload implements \JsonSerializable
      * @return array
      * @link   http://php.net/manual/en/jsonserializable.jsonserialize.php
      */
+    #[\ReturnTypeWillChange]
     public function jsonSerialize()
     {
         $payload = self::getDefaultPayloadStructure();

--- a/src/Payload/Alert.php
+++ b/src/Payload/Alert.php
@@ -325,6 +325,7 @@ class Alert implements \JsonSerializable
      * @return array
      * @link   http://php.net/manual/en/jsonserializable.jsonserialize.php
      */
+    #[\ReturnTypeWillChange]
     public function jsonSerialize()
     {
         $alert = [];

--- a/src/Payload/Sound.php
+++ b/src/Payload/Sound.php
@@ -139,6 +139,7 @@ class Sound implements \JsonSerializable
      * @return array
      * @link   http://php.net/manual/en/jsonserializable.jsonserialize.php
      */
+    #[\ReturnTypeWillChange]
     public function jsonSerialize()
     {
         $sound = [];


### PR DESCRIPTION
Prevent deprecation warning when updating to PHP 8.1 while preserving PHP 8.0 compatibility.

This will allow the lib user to make sure they don't have deprecation warnings on their way to 8.1 update

See #166 