### PR TITLE
Fixes deprecated JWT libraries + bump phpunit to ^10.5 

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,4 @@ composer.lock
 docs
 vendor
 .phpunit.result.cache
+.phpunit.cache

--- a/composer.json
+++ b/composer.json
@@ -21,19 +21,18 @@
     "require": {
         "php": "^8.1",
         "ext-curl": "*",
-        "lib-curl": ">=7.46.0",
-        "ext-openssl": "*",
-        "lib-openssl": ">=1.0.2.5",
-        "ext-json": "*",
-        "ext-xml": "*",
         "ext-intl": "*",
-        "web-token/jwt-signature-algorithm-ecdsa": "^3.0",
-        "web-token/jwt-key-mgmt": "^3.0"
+        "ext-json": "*",
+        "ext-openssl": "*",
+        "ext-xml": "*",
+        "lib-curl": ">=7.46.0",
+        "lib-openssl": ">=1.0.2.5",
+        "web-token/jwt-library": "^3.0"
     },
     "require-dev": {
         "ext-xdebug": "*",
         "php-coveralls/php-coveralls": "^2.0",
-        "phpunit/phpunit": "^8.4",
+        "phpunit/phpunit": "^10.5",
         "squizlabs/php_codesniffer": "^3.4"
     },
     "autoload": {

--- a/phpunit.xml.dist
+++ b/phpunit.xml.dist
@@ -1,29 +1,31 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<phpunit bootstrap="vendor/autoload.php"
+<phpunit xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         bootstrap="vendor/autoload.php"
          backupGlobals="false"
-         backupStaticAttributes="false"
          colors="true"
-         verbose="true"
-         convertErrorsToExceptions="true"
-         convertNoticesToExceptions="true"
-         convertWarningsToExceptions="true"
          processIsolation="false"
-         stopOnFailure="false">
-    <testsuites>
-        <testsuite name="Pushok Test Suite">
-            <directory>tests</directory>
-        </testsuite>
-    </testsuites>
-    <filter>
-        <whitelist>
-            <directory suffix=".php">src/</directory>
-        </whitelist>
-    </filter>
-    <logging>
-        <log type="tap" target="build/report.tap"/>
-        <log type="junit" target="build/report.junit.xml"/>
-        <log type="coverage-html" target="build/coverage"/>
-        <log type="coverage-text" target="build/coverage.txt"/>
-        <log type="coverage-clover" target="build/logs/clover.xml"/>
-    </logging>
+         stopOnFailure="false"
+         xsi:noNamespaceSchemaLocation="https://schema.phpunit.de/10.5/phpunit.xsd"
+         cacheDirectory=".phpunit.cache"
+         backupStaticProperties="false">
+  <coverage>
+    <report>
+      <clover outputFile="build/logs/clover.xml"/>
+      <html outputDirectory="build/coverage"/>
+      <text outputFile="build/coverage.txt"/>
+    </report>
+  </coverage>
+  <testsuites>
+    <testsuite name="Pushok Test Suite">
+      <directory>tests</directory>
+    </testsuite>
+  </testsuites>
+  <logging>
+    <junit outputFile="build/report.junit.xml"/>
+  </logging>
+  <source>
+    <include>
+      <directory suffix=".php">src/</directory>
+    </include>
+  </source>
 </phpunit>

--- a/tests/NotificationTest.php
+++ b/tests/NotificationTest.php
@@ -16,7 +16,7 @@ use PHPUnit\Framework\TestCase;
 use Pushok\Notification;
 use Pushok\Payload;
 
-class MessageTest extends TestCase
+class NotificationTest extends TestCase
 {
     public function testGetDeviceToken()
     {


### PR DESCRIPTION
Hi!
This PR to get rid of the deprecation notice regarding the JWT libraries.
Also I bump phpunit to ^10.5. This last move has one downside as the author of phpunit has removed TAP logging.