### PR TITLE
Add attribute support for live activity widgets

### DIFF
--- a/src/Payload.php
+++ b/src/Payload.php
@@ -47,6 +47,8 @@ class Payload implements \JsonSerializable
     const PAYLOAD_RELEVANCE_SCORE_KEY = 'relevance-score';
     const PAYLOAD_STALE_DATE_KEY = 'stale-date';
     const PAYLOAD_CONTENT_STATE_KEY = 'content-state';
+    const PAYLOAD_ATTRIBUTES_TYPE_KEY = 'attributes-type';
+    const PAYLOAD_ATTRIBUTES_KEY = 'attributes';
 
     const PAYLOAD_HTTP2_REGULAR_NOTIFICATION_MAXIMUM_SIZE = 4096;
     const PAYLOAD_HTTP2_VOIP_NOTIFICATION_MAXIMUM_SIZE = 5120;
@@ -168,6 +170,20 @@ class Payload implements \JsonSerializable
      * @var array
      */
     private $contentState;
+
+    /**
+     * Attributes type
+     *
+     * @var string|null
+     */
+    private string|null $attributesType;
+
+    /**
+     * Attributes
+     *
+     * @var array
+     */
+    private array $attributes = [];
 
     protected function __construct()
     {
@@ -593,6 +609,66 @@ class Payload implements \JsonSerializable
     public function getEvent()
     {
         return $this->event;
+    }
+
+    /**
+     * Set attributes type for Payload.
+     *
+     * @param string $attributesType
+     * @return Payload
+     */
+    public function setAttributesType(string $attributesType): self
+    {
+        $this->attributesType = $attributesType;
+
+        return $this;
+    }
+
+    /**
+     * Get attributes type for Payload.
+     *
+     * @return string|null
+     */
+    public function getAttributesType(): string|null
+    {
+        return $this->attributesType;
+    }
+
+    /**
+     * Add an attribute to the payload.
+     *
+     * @param string $key
+     * @param mixed $value
+     * @return Payload
+     */
+    public function addAttribute(string $key, mixed $value): Payload
+    {
+        $this->attributes[$key] = $value;
+
+        return $this;
+    }
+
+    /**
+     * Add an array of attributes to the payload.
+     *
+     * @param array $attributes
+     * @return Payload
+     */
+    public function addAttributes(array $attributes): Payload
+    {
+        $this->attributes = array_merge($this->attributes, $attributes);
+
+        return $this;
+    }
+
+    /**
+     * Get Attributes
+     *
+     * @return array
+     */
+    public function getAttributes(): array
+    {
+        return $this->attributes;
     }
 
     /**

--- a/src/Payload.php
+++ b/src/Payload.php
@@ -47,6 +47,7 @@ class Payload implements \JsonSerializable
     const PAYLOAD_RELEVANCE_SCORE_KEY = 'relevance-score';
     const PAYLOAD_STALE_DATE_KEY = 'stale-date';
     const PAYLOAD_CONTENT_STATE_KEY = 'content-state';
+    const PAYLOAD_DISMISSAL_DATE_KEY = 'dismissal-date';
     const PAYLOAD_ATTRIBUTES_TYPE_KEY = 'attributes-type';
     const PAYLOAD_ATTRIBUTES_KEY = 'attributes';
 
@@ -184,6 +185,13 @@ class Payload implements \JsonSerializable
      * @var array
      */
     private $attributes = [];
+
+    /**
+     * Dismissal date
+     *
+     * @var int|null
+     */
+    private $dismissalDate;
 
     protected function __construct()
     {
@@ -672,6 +680,18 @@ class Payload implements \JsonSerializable
         return $this->attributes;
     }
 
+    public function setDismissalDate(int $value): Payload
+    {
+        $this->dismissalDate = $value;
+
+        return $this;
+    }
+
+    public function getDismissalDate(): int|null
+    {
+        return $this->dismissalDate;
+    }
+
     /**
      * Convert Payload to JSON.
      *
@@ -763,6 +783,10 @@ class Payload implements \JsonSerializable
 
         if (is_double($this->relevanceScore)) {
             $payload[self::PAYLOAD_ROOT_KEY]->{self::PAYLOAD_RELEVANCE_SCORE_KEY} = $this->relevanceScore;
+        }
+
+        if ($this->dismissalDate) {
+            $payload[self::PAYLOAD_ROOT_KEY]->{self::PAYLOAD_DISMISSAL_DATE_KEY} = (int) $this->getDismissalDate();
         }
 
         if ($this->attributesType) {

--- a/src/Payload.php
+++ b/src/Payload.php
@@ -176,14 +176,14 @@ class Payload implements \JsonSerializable
      *
      * @var string|null
      */
-    private string|null $attributesType;
+    private $attributesType;
 
     /**
      * Attributes
      *
      * @var array
      */
-    private array $attributes = [];
+    private $attributes = [];
 
     protected function __construct()
     {

--- a/src/Payload.php
+++ b/src/Payload.php
@@ -613,6 +613,7 @@ class Payload implements \JsonSerializable
 
     /**
      * Set attributes type for Payload.
+     * This is used to specify the interpreter of the attributes on the apple side.
      *
      * @param string $attributesType
      * @return Payload
@@ -762,6 +763,11 @@ class Payload implements \JsonSerializable
 
         if (is_double($this->relevanceScore)) {
             $payload[self::PAYLOAD_ROOT_KEY]->{self::PAYLOAD_RELEVANCE_SCORE_KEY} = $this->relevanceScore;
+        }
+
+        if ($this->attributesType) {
+            $payload[self::PAYLOAD_ROOT_KEY]->{self::PAYLOAD_ATTRIBUTES_TYPE_KEY} = $this->attributesType;
+            $payload[self::PAYLOAD_ROOT_KEY]->{self::PAYLOAD_ATTRIBUTES_KEY} = $this->attributes;
         }
 
         return $payload;

--- a/tests/PayloadTest.php
+++ b/tests/PayloadTest.php
@@ -103,6 +103,23 @@ class PayloadTest extends TestCase
             ->getCustomValue('notExistingKey', 'value');
     }
 
+    public function testSetDismissalDate()
+    {
+        $payload = Payload::create()->setDismissalDate(123456789);
+
+        $this->assertEquals(123456789, $payload->getDismissalDate());
+    }
+
+    public function testDismissalDateJson()
+    {
+        $payload = Payload::create()
+            ->setDismissalDate(123456789);
+        $this->assertJsonStringEqualsJsonString(
+            '{"aps":{"dismissal-date":123456789}}',
+            $payload->toJson()
+        );
+    }
+
     public function testSetAttributesType()
     {
         $payload = Payload::create()->setAttributesType('attributesType');

--- a/tests/PayloadTest.php
+++ b/tests/PayloadTest.php
@@ -103,6 +103,52 @@ class PayloadTest extends TestCase
             ->getCustomValue('notExistingKey', 'value');
     }
 
+    public function testSetAttributesType()
+    {
+        $payload = Payload::create()->setAttributesType('attributesType');
+
+        $this->assertEquals('attributesType', $payload->getAttributesType());
+    }
+
+    public function testAddAttribute()
+    {
+        $payload = Payload::create()
+            ->addAttribute('key', 'value')
+            ->addAttribute('key2', 'value2');
+
+        $this->assertEquals(['key' => 'value', 'key2' => 'value2'], $payload->getAttributes());
+    }
+
+    public function testAddAttributesMergesWithExisting()
+    {
+        $payload = Payload::create()
+            ->addAttributes(['key3' => 'value3', 'key' => 'replaced'])
+            ->addAttributes(['key' => 'value', 'key2' => 'value2']);
+
+        $this->assertEquals(['key' => 'value', 'key2' => 'value2', 'key3' => 'value3'], $payload->getAttributes());
+    }
+
+    public function testAttributesJsonSerializeCorrectly()
+    {
+        $payload = Payload::create()
+            ->setAttributesType('attributesType')
+            ->addAttributes(['key' => 'value', 'key2' => 'value2']);
+        $this->assertJsonStringEqualsJsonString(
+            '{"aps":{"attributes-type":"attributesType","attributes":{"key":"value","key2":"value2"}}}',
+            $payload->toJson()
+        );
+    }
+
+    public function testAttributesIgnoredIfNoAttributesType()
+    {
+        $payload = Payload::create()
+            ->addAttributes(['key' => 'value', 'key2' => 'value2']);
+        $this->assertJsonStringEqualsJsonString(
+            '{"aps":{}}',
+            $payload->toJson()
+        );
+    }
+
     public function testSetPushType()
     {
         $payload = Payload::create()->setPushType('pushType');


### PR DESCRIPTION
This allows the passing of `attributes-type` , `attributes` and `dismissal-date` which are all used for LiveActivity pushes.

![Screenshot 2025-01-24 at 14 26 04](https://github.com/user-attachments/assets/8bad23ad-9067-4cf4-b9ee-934aef6970eb)
https://developer.apple.com/documentation/usernotifications/generating-a-remote-notification