### PR TITLE
Add support for DER and P12 certificates

### DIFF
--- a/README.md
+++ b/README.md
@@ -110,7 +110,7 @@ foreach ($responses as $response) {
 }
 ```
 
-Using Certificate (.pem). Only the initilization differs from JWT code (above). Remember to include the rest of the code by yourself.
+Using Certificate (.pem or .p12). Only the initilization differs from JWT code (above). Remember to include the rest of the code by yourself.
 
 ``` php
 <?php

--- a/src/AuthProvider/Certificate.php
+++ b/src/AuthProvider/Certificate.php
@@ -76,6 +76,16 @@ class Certificate implements AuthProviderInterface
      */
     public function authenticateClient(Request $request)
     {
+        # OpenSSL (versions 0.9.3 and later) also support "P12" for PKCS#12-encoded files.
+        # see https://curl.se/libcurl/c/CURLOPT_SSLCERTTYPE.html
+        $ext = pathinfo($this->certificatePath, \PATHINFO_EXTENSION);
+        if (preg_match('#^(der|p12)$#i', $ext)) {
+            $request->addOptions(
+                [
+                    CURLOPT_SSLCERTTYPE => strtoupper($ext)
+                ]
+            );
+        }
         $request->addOptions(
             [
                 CURLOPT_SSLCERT        => $this->certificatePath,

--- a/tests/AuthProvider/CertificateTest.php
+++ b/tests/AuthProvider/CertificateTest.php
@@ -39,6 +39,27 @@ class CertificateTest extends TestCase
         $this->assertSame($request->getOptions()[CURLOPT_SSLCERTPASSWD], $options['certificate_secret']);
     }
 
+    public function testAuthenticatingClientP12()
+    {
+        $certFile = tempnam(sys_get_temp_dir(), "mock_test_cert");
+        rename($certFile, $certFile .= '.p12');
+        try {
+            $options = [
+                'certificate_path' => $certFile,
+                'certificate_secret' => 'secret',
+                'app_bundle_id' => 'com.apple.test',
+            ];
+            $authProvider = Certificate::create($options);
+
+            $request = $this->createRequest();
+            $authProvider->authenticateClient($request);
+
+            $this->assertSame($request->getOptions()[CURLOPT_SSLCERTTYPE], 'P12');
+        } finally {
+            @\unlink($certFile);
+        }
+    }
+
     public function testVoipApnsTopic()
     {
         $options = $this->getOptions();


### PR DESCRIPTION
Identical with https://github.com/guzzle/guzzle/pull/2413

Reasoning behind it is that for Apple Wallet push notifications, the same APN endpoint is used, just with an empty body and with the `topic` = `appBundleId` = `passTypeIdentifier`. Since we need the P12 certificate format to sign the passes, it makes sense to use the same file for push notifications, without requiring a copy in PEM format.

Tested locally and it works beautifully, thank you for your work!

Documentation:
- https://curl.haxx.se/libcurl/c/CURLOPT_SSLCERTTYPE.html
- https://developer.apple.com/documentation/walletpasses/building-a-pass#Sign-the-Pass-and-Create-the-Bundle
- https://developer.apple.com/documentation/walletpasses/adding-a-web-service-to-update-passes#Send-a-Push-Notification