### PR TITLE
Updated web-token/jwt-library to 4.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Pushok
 
-[![PHP >= 8.8](https://img.shields.io/badge/php-%3E%3D%208.2-8892BF.svg?style=flat-square)](https://php.net/)
+[![PHP >= 8.2](https://img.shields.io/badge/php-%3E%3D%208.2-8892BF.svg?style=flat-square)](https://php.net/)
 [![Build Status][ico-travis]][link-travis]
 [![Latest Version on Packagist][ico-version]][link-packagist]
 [![Total Downloads][ico-downloads]][link-downloads]

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Pushok
 
-[![PHP >= 8.1](https://img.shields.io/badge/php-%3E%3D%208.1-8892BF.svg?style=flat-square)](https://php.net/)
+[![PHP >= 8.8](https://img.shields.io/badge/php-%3E%3D%208.2-8892BF.svg?style=flat-square)](https://php.net/)
 [![Build Status][ico-travis]][link-travis]
 [![Latest Version on Packagist][ico-version]][link-packagist]
 [![Total Downloads][ico-downloads]][link-downloads]
@@ -24,7 +24,7 @@ Pushok is a simple PHP library for sending push notifications to APNs.
 
 ## Requirements
 
-* PHP >= 8.1
+* PHP >= 8.2
 * lib-curl >= 7.46.0 (with http/2 support enabled)
 * lib-openssl >= 1.0.2e 
 

--- a/composer.json
+++ b/composer.json
@@ -25,7 +25,7 @@
         "ext-openssl": "*",
         "lib-curl": ">=7.46.0",
         "lib-openssl": ">=1.0.2.5",
-        "web-token/jwt-library": "^3.0"
+        "web-token/jwt-library": "^4.0"
     },
     "require-dev": {
         "php-coveralls/php-coveralls": "^2.0",

--- a/composer.json
+++ b/composer.json
@@ -19,7 +19,7 @@
         }
     ],
     "require": {
-        "php": "^8.1",
+        "php": "^8.2",
         "ext-curl": "*",
         "ext-json": "*",
         "ext-openssl": "*",


### PR DESCRIPTION
This was surprisingly easy. The API stayed mostly the same between v3 and v4 and pushok uses none of the removed or deprecated features, so I only had to raise the version number and minimum PHP version.